### PR TITLE
fix warnings about signed/unsigned comparison in umich matd.h

### DIFF
--- a/apriltag_umich/src/common/matd.h
+++ b/apriltag_umich/src/common/matd.h
@@ -277,7 +277,7 @@ static inline int matd_is_vector(const matd_t *a)
 static inline int matd_is_vector_len(const matd_t *a, int len)
 {
     assert(a != NULL);
-    return (a->ncols == 1 && a->nrows == len) || (a->ncols == len && a->nrows == 1);
+    return (a->ncols == 1 && (int)a->nrows == len) || ((int)a->ncols == len && a->nrows == 1);
 }
 
 /**


### PR DESCRIPTION
This header file causes compiler warnings when other packages include e.g. "apriltag_ros/apritag_detector.h"

