### PR TITLE
change HUGE to HUGE_VAL for ubuntu 18.04

### DIFF
--- a/apriltag_umich/src/common/image_f32.c
+++ b/apriltag_umich/src/common/image_f32.c
@@ -152,7 +152,7 @@ void image_f32_gaussian_blur(image_f32_t *im, double sigma, int ksz)
 // remap all values to [0, 1]
 void image_f32_normalize(image_f32_t *im)
 {
-    float min = HUGE, max = -HUGE;
+    float min = HUGE_VAL, max = -HUGE_VAL;
 
     for (int y = 0; y < im->height; y++) {
         for (int x = 0; x < im->width; x++) {


### PR DESCRIPTION
this change was necessary to compile on ubuntu 18.04.
Backtested: it also compiles on ubuntu 16.04

Not sure what changed and why this no longer compiled, couldn't find any change log that indicated how HUGE disappeared
