### PR TITLE
fix apriltag_ros dependencies on apriltag_umich

### DIFF
--- a/apriltag_ros/CMakeLists.txt
+++ b/apriltag_ros/CMakeLists.txt
@@ -17,7 +17,7 @@ find_package(catkin REQUIRED
                         tf2_geometry_msgs
                         apriltag_mit
                         apriltag_msgs)
-find_package(apriltag REQUIRED)
+find_package(apriltag REQUIRED)  # this is actually the umich package
 
 generate_dynamic_reconfigure_options(cfg/ApriltagDetectorDyn.cfg)
 

--- a/apriltag_ros/package.xml
+++ b/apriltag_ros/package.xml
@@ -17,7 +17,7 @@
   <depend>tf2_geometry_msgs</depend>
 
   <depend>apriltag_mit</depend>
-  <depend>apriltag_umich</depend>
+  <depend>apriltag</depend>
   <depend>apriltag_msgs</depend>
 
   <build_depend>message_generation</build_depend>


### PR DESCRIPTION
There is no apriltag_umich package. It's actually called "apriltag", so the dependencies are somewhat messed up.

`catkin build apriltag_ros`

fails. This PR fixes that.
