### PR TITLE
Update apriltag_umich submodule to latest update

### DIFF
--- a/apriltag_umich/apriltag_umich.rosinstall
+++ b/apriltag_umich/apriltag_umich.rosinstall
@@ -1,1 +1,1 @@
-- git: {local-name: apriltag/apriltag_umich/apriltag, uri: 'https://github.com/AprilRobotics/apriltag.git', version: 'v3.3.0'}
+- git: {local-name: apriltag/apriltag_umich/apriltag, uri: 'https://github.com/AprilRobotics/apriltag.git', version: 'e6cd3c7afdc23814f38a6b537904a41c393fc305'}


### PR DESCRIPTION
Originally the latest master of [apriltag_umich](https://github.com/AprilRobotics/apriltag) will not work due to CMake incompatibilities in that package. The fixing MR is accepted and now we can point to the latest version: 
https://github.com/AprilRobotics/apriltag/commit/e6cd3c7afdc23814f38a6b537904a41c393fc305
I didn't choose to point to the master branch because I'm not sure if it would break again, but of course you can change it.